### PR TITLE
v1.0.1 is set to master in version mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ There is no way to configure this on a per index basis.
 
 |     Http Basic Plugin       | elasticsearch         |
 |-----------------------------|-----------------------|
-| 1.1.0                       | 1.0.0                 |
-| 1.0.4(master)               | 0.90.7                |
+| 1.1.0(master)               | 1.0.0                 |
+| 1.0.4                       | 0.90.7                |
 
 ## Installation
 


### PR DESCRIPTION
Corrected wrong information in Readme in the **version mappings** section
