### PR TITLE
resolves #26 update to es 1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 **IMPORTANT NOTICE**: versions 1.0.4 and 1.1.0 are *insecure and should not be used*.
 They have a bug that allows an attacker to get ip authentication by setting
-its ip on the 'Host' header. A fix is provided for now for versions v1.2.0 and
+its ip on the 'Host' header. A fix is provided for versions v1.2.0 and
 v.1.3.0 of the plugin.
 
 # HTTP Basic auth for ElasticSearch
@@ -18,6 +18,7 @@ There is no way to configure this on a per index basis.
 
 |     Http Basic Plugin       | elasticsearch         |
 |-----------------------------|-----------------------|
+| v1.4.0.Beta1 (1.4.0.Beta1)  | 1.4.0.Beta1           |
 | v1.3.0(master)              | 1.3.0                 |
 | v1.2.0                      | 1.2.0                 |
 | 1.1.0                       | 1.0.0                 |

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ There is no way to configure this on a per index basis.
 
 |     Http Basic Plugin       | elasticsearch         |
 |-----------------------------|-----------------------|
-| v1.4.0.Beta1 (1.4.0.Beta1)  | 1.4.0.Beta1           |
-| v1.3.0(master)              | 1.3.0                 |
+| v1.4.0(master)              | 1.4.0                 |
+| v1.3.0                      | 1.3.0                 |
 | v1.2.0                      | 1.2.0                 |
 | 1.1.0                       | 1.0.0                 |
 | 1.0.4                       | 0.90.7                |

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.asquera.elasticsearch</groupId>
     <artifactId>elasticsearch-http-basic</artifactId>
-    <version>1.3.0</version>
+    <version>1.4.0</version>
     <packaging>jar</packaging>
 
     <name>Basic Authentication Plugin</name>
@@ -12,8 +12,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <elasticsearch.version>1.3.0</elasticsearch.version>
-        <lucene.version>4.9.0</lucene.version>
+        <elasticsearch.version>1.4.0.Beta1</elasticsearch.version>
+        <lucene.version>4.10.1</lucene.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -12,8 +12,9 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <elasticsearch.version>1.4.0.Beta1</elasticsearch.version>
-        <lucene.version>4.10.1</lucene.version>
+        <elasticsearch.version>1.4.0</elasticsearch.version>
+        <lucene.version>4.10.2</lucene.version>
+        <lucene.maven.version>4.10.2</lucene.maven.version>
     </properties>
 
     <dependencies>
@@ -21,7 +22,7 @@
        <dependency>
           <groupId>org.apache.lucene</groupId>
           <artifactId>lucene-test-framework</artifactId>
-          <version>${lucene.version}</version>
+          <version>${lucene.maven.version}</version>
           <scope>test</scope>
         </dependency>
 
@@ -32,6 +33,12 @@
           <scope>test</scope>
         </dependency>
 
+        <dependency>
+          <groupId>com.carrotsearch.randomizedtesting</groupId>
+          <artifactId>randomizedtesting-runner</artifactId>
+          <version>2.1.10</version>
+          <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.elasticsearch</groupId>
             <artifactId>elasticsearch</artifactId>

--- a/src/main/java/com/asquera/elasticsearch/plugins/http/HttpBasicServerModule.java
+++ b/src/main/java/com/asquera/elasticsearch/plugins/http/HttpBasicServerModule.java
@@ -7,12 +7,13 @@ import org.elasticsearch.common.settings.Settings;
  * @author Florian Gilcher (florian.gilcher@asquera.de)
  */
 public class HttpBasicServerModule extends HttpServerModule {
-    
+
     public HttpBasicServerModule(Settings settings) {
         super(settings);
     }
-    
+
     @Override protected void configure() {
+        super.configure();
         bind(HttpBasicServer.class).asEagerSingleton();
     }
 }

--- a/src/test/java/com/asquera/elasticsearch/plugins/http/auth/integration/DefaultConfigurationIntegrationTest.java
+++ b/src/test/java/com/asquera/elasticsearch/plugins/http/auth/integration/DefaultConfigurationIntegrationTest.java
@@ -18,33 +18,24 @@
  */
 package com.asquera.elasticsearch.plugins.http.auth.integration;
 
-
-import org.apache.http.impl.client.HttpClients;
-import org.elasticsearch.common.settings.ImmutableSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.rest.RestStatus;
-import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.elasticsearch.test.ElasticsearchIntegrationTest.ClusterScope;
 import org.elasticsearch.test.ElasticsearchIntegrationTest.Scope;
-import org.elasticsearch.test.rest.client.http.HttpRequestBuilder;
 import org.elasticsearch.test.rest.client.http.HttpResponse;
 import org.junit.Test;
-
-import com.asquera.elasticsearch.plugins.http.HttpBasicServerPlugin;
 
 import static org.hamcrest.Matchers.equalTo;
 
 /**
  * Test a rest action that sets special response headers
  */
-@ClusterScope(transportClientRatio = 0.0, scope = Scope.SUITE, numDataNodes = 1)
-public class DefaultConfigurationIntegrationTest extends ElasticsearchIntegrationTest {
+@ClusterScope(scope = Scope.SUITE, numDataNodes = 1)
+public class DefaultConfigurationIntegrationTest extends HttpBasicServerPluginIntegrationTest {
 
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {
-        return ImmutableSettings.settingsBuilder()
-                .put("plugin.types", HttpBasicServerPlugin.class.getName())
-                .build();
+      return builderWithPlugin().build();
     }
 
     @Test
@@ -54,12 +45,8 @@ public class DefaultConfigurationIntegrationTest extends ElasticsearchIntegratio
     }
 
     @Test
-    public void localhostClientIsAuthenticated() throws Exception {
+    public void localhostClientIsIpAuthenticated() throws Exception {
         HttpResponse response = httpClient().path("/_status").execute();
         assertThat(response.getStatusCode(), equalTo(RestStatus.OK.getStatus()));
-    }
-   
-    public static HttpRequestBuilder httpClient() {
-        return new HttpRequestBuilder(HttpClients.createDefault()).host("localhost").port(9200);
     }
 }

--- a/src/test/java/com/asquera/elasticsearch/plugins/http/auth/integration/HttpBasicServerPluginIntegrationTest.java
+++ b/src/test/java/com/asquera/elasticsearch/plugins/http/auth/integration/HttpBasicServerPluginIntegrationTest.java
@@ -1,0 +1,49 @@
+
+package com.asquera.elasticsearch.plugins.http.auth.integration;
+
+
+import java.net.InetSocketAddress;
+
+import org.apache.http.impl.client.HttpClients;
+import org.elasticsearch.common.transport.InetSocketTransportAddress;
+import org.elasticsearch.common.Base64;
+import org.elasticsearch.http.HttpServerTransport;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.elasticsearch.test.rest.client.http.HttpRequestBuilder;
+import com.asquera.elasticsearch.plugins.http.HttpBasicServerPlugin;
+import org.elasticsearch.common.settings.ImmutableSettings.Builder;
+import org.elasticsearch.common.settings.ImmutableSettings;
+
+/**
+ *
+ * @author Ernesto Miguez (ernesto.miguez@asquera.de)
+ */
+
+public abstract class HttpBasicServerPluginIntegrationTest extends
+ElasticsearchIntegrationTest {
+
+  protected final String localhost = "127.0.0.1";
+
+
+  public static HttpRequestBuilder httpClient() {
+    HttpServerTransport httpServerTransport = internalCluster().getDataNodeInstance(HttpServerTransport.class);
+    InetSocketAddress address = ((InetSocketTransportAddress) httpServerTransport.boundAddress().publishAddress()).address();
+    return new HttpRequestBuilder(HttpClients.createDefault()).host(address.getHostName()).port(address.getPort());
+  }
+  /**
+   *
+   * @return a Builder with the plugin included and bind_host and publish_host
+   * set to localhost, from where the client's request ip will be done.
+   */
+  protected Builder builderWithPlugin() {
+    return ImmutableSettings.settingsBuilder()
+      .put("network.host", localhost)
+      .put("plugin.types", HttpBasicServerPlugin.class.getName());
+  }
+
+  protected HttpRequestBuilder requestWithCredentials(String credentials) throws Exception {
+        return httpClient().path("/_status")
+          .addHeader("Authorization", "Basic " + Base64.encodeBytes(credentials.getBytes()));
+    }
+
+}


### PR DESCRIPTION
commit https://github.com/elasticsearch/elasticsearch/commit/10af60bd1e459b549c43435bf6e89ce5eb76b8be
changes how transport module is initialized, breaking HttpBasicServerModule for Guice.
- updated depenencies
- HttpBasicServerModule inherits calls HttpServerModule's configure, which binds an HttpServerTransport

Updated integration tests

- new abstract class for common functionality, from which all integration
  tests inherit.
- using the HttpRequestBuilder for buliding the request.
- abstract class HttpBasicServerPluginIntegrationTest sets the host to
  localhost. The test requests will also have localhost, making
  tests consistent.