### PR TITLE
ES 1.5.x compatiblity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ deploy.sh
 .project
 .settings/
 data/
+/.local-execution-hints.log
+/.local-*-execution-hints.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,10 @@
+sudo: false
 language: java
+script: ./script/ci/run_build.sh
+env:
+  - ES_VERSION=1.5.0
+  - ES_VERSION=1.5.1
+  - ES_VERSION=1.5.2
+cache:
+  directories:
+    - $HOME/.m2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@ All notable changes to this project will be documented in this
 file. This file is structured according to http://keepachangelog.com/
 
 - - -
-
-## [1.4.1-pre][unreleased]
+## [1.5.0][unreleased]
+### - Added
+- allow disabling ipwhitelist by setting its value to `false`
+- updated pom to depend on elasticsearch-parent project
+- better travis test for different ES versions
 
 ### Changed
 - restored default healthcheck for authenticated users &&

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/Asquera/elasticsearch-http-basic.svg?branch=1.4)](https://travis-ci.org/Asquera/elasticsearch-http-basic)
+[![Build Status](https://travis-ci.org/emig/elasticsearch-http-basic.svg?branch=1.5)](https://travis-ci.org/emig/elasticsearch-http-basic)
 
 **IMPORTANT NOTICE**: versions 1.0.4 is *insecure and should not be used*.
 They have a bug that allows an attacker to get ip authentication by setting

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/Asquera/elasticsearch-http-basic.svg?branch=master)](https://travis-ci.org/Asquera/elasticsearch-http-basic)
+[![Build Status](https://travis-ci.org/Asquera/elasticsearch-http-basic.svg?branch=1.4)](https://travis-ci.org/Asquera/elasticsearch-http-basic)
 
 **IMPORTANT NOTICE**: versions 1.0.4 is *insecure and should not be used*.
 They have a bug that allows an attacker to get ip authentication by setting

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/emig/elasticsearch-http-basic.svg?branch=1.5)](https://travis-ci.org/emig/elasticsearch-http-basic)
+[![Build Status](https://travis-ci.org/Asquera/elasticsearch-http-basic.svg?branch=master)](https://travis-ci.org/Asquera/elasticsearch-http-basic)
 
 **IMPORTANT NOTICE**: versions 1.0.4 is *insecure and should not be used*.
 They have a bug that allows an attacker to get ip authentication by setting
@@ -18,7 +18,8 @@ There is no way to configure this on a per index basis.
 
 |     Http Basic Plugin       | elasticsearch         |
 |-----------------------------|-----------------------|
-| v1.4.0(master)              | 1.4.0                 |
+| v1.5.0(master)              | 1.5.x                 |
+| v1.4.0                      | 1.4.0                 |
 | v1.3.0                      | 1.3.0                 |
 | v1.2.0                      | 1.2.0                 |
 | 1.1.0                       | 1.0.0                 |
@@ -26,7 +27,7 @@ There is no way to configure this on a per index basis.
 
 ## Installation
 
-Download the current version from https://github.com/Asquera/elasticsearch-http-basic/releases and copy it to `plugins/http-basic`.
+Download the desired version from https://github.com/Asquera/elasticsearch-http-basic/releases and copy it to `plugins/http-basic`.
 
 ## Configuration
 
@@ -36,8 +37,8 @@ Once the plugin is installed it can be configured in the [elasticsearch modules 
 |-----------------------------------|------------------------------|-------------------------------------------------------------------------|
 | `http.basic.enabled`              | true                         | **true** disables the default ES HTTP Transport module                  |
 | `http.basic.user`                 | "admin"                      |                                                                         |
-| `http.basic.password`              | "admin_pw"                   |                                                                         |
-| `http.basic.ipwhitelist`            | ["localhost", "127.0.0.1"]   | uses Host Name Resolution from [java.net.InetAddress](http://docs.oracle.com/javase/7/docs/api/java/net/InetAddress.html)                     |
+| `http.basic.password`             | "admin_pw"                   |                                                                         |
+| `http.basic.ipwhitelist`          | ["localhost", "127.0.0.1"]   | If set to `false` no ip will be whitelisted. Uses Host Name Resolution from [java.net.InetAddress](http://docs.oracle.com/javase/7/docs/api/java/net/InetAddress.html)                     |
 | `http.basic.trusted_proxy_chains` | []                           | Set an array of trusted proxies ips chains                              |
 | `http.basic.log`                  | false                        | enables plugin logging to ES log. Unauthenticated requests are always logged.                                         |
 | `http.basic.xforward`             | ""                           | most common is [X-Forwarded-For](http://en.wikipedia.org/wiki/X-Forwarded-For) |
@@ -123,14 +124,19 @@ http.basic.trusted_proxy_chains: ["1.1.1.1,2.2.2.2"]
 
 ## Testing
 
+**note:** localhost is a whitelisted ip as default.
+Considering a default configuration with **my_username** and **my_password** configured.
+
+Correct credentials
 ```
-$ curl -v localhost:9200 # works
-$ curl -v --user my_username:my_password localhost:9200/foo # works
+$ curl -v localhost:9200 # works (returns 200) (by default localhost is configured as whitelisted ip)
+$ curl -v --user my_username:my_password no_local_host:9200/foo # works (returns 200) (if credentials are set in configuration)
 ```
 
-**note:** localhost is a whitelisted ip as default.
+Wrong credentials
 ```
-$ curl -v --user my_username:password localhost:9200/foo # sends 401
+$ curl -v --user my_username:wrong_password no_local_host:9200/    # health check, returns 200 with  "{\"OK\":{}}" although Unauthorized
+$ curl -v --user my_username:password no_local_host:9200/foo       # returns 401
 ```
 
 ## Development
@@ -139,8 +145,8 @@ $ curl -v --user my_username:password localhost:9200/foo # sends 401
   Maven is configured to run the unit and integration tests. This plugin makes
   use of [ES Integration Tests](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/integration-tests.html)
 
-  `mvn test` test runs all tests
-  `mvn integration-test` test runs integration tests only
+  `mvn test -Dtests.security.manager=false` test runs all tests
+  `mvn integration-test -Dtests.security.manager=false` test runs integration tests only
 
 ## Issues
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,110 +1,98 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  exmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.asquera.elasticsearch</groupId>
+  <artifactId>elasticsearch-http-basic</artifactId>
+  <version>1.5.0</version>
+  <packaging>jar</packaging>
+  <name>Elasticsearch Http Basic plugin</name>
+  <description>Adds HTTP Basic authentication (BA) to your Elasticsearch cluster</description>
+  <url>https://github.com/Asquera/elasticsearch-http-basic/</url>
+  <inceptionYear>2011</inceptionYear>
 
-    <groupId>com.asquera.elasticsearch</groupId>
-    <artifactId>elasticsearch-http-basic</artifactId>
-    <version>1.4.1-pre</version>
-    <packaging>jar</packaging>
+  <parent>
+    <groupId>org.elasticsearch</groupId>
+    <artifactId>elasticsearch-parent</artifactId>
+    <version>1.5.0</version>
+  </parent>
 
-    <name>Basic Authentication Plugin</name>
-    <url>http://maven.apache.org</url>
+  <properties>
+    <tests.jvms>1</tests.jvms>
+    <es.logger.level>INFO</es.logger.level>
+  </properties>
 
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <elasticsearch.version>1.4.0</elasticsearch.version>
-        <lucene.version>4.10.2</lucene.version>
-        <lucene.maven.version>4.10.2</lucene.maven.version>
-    </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.3.5</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.carrotsearch.randomizedtesting</groupId>
+      <artifactId>randomizedtesting-runner</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.lucene</groupId>
+      <artifactId>lucene-test-framework</artifactId>
+    </dependency>
 
-    <dependencies>
+    <dependency>
+      <groupId>org.elasticsearch</groupId>
+      <artifactId>elasticsearch</artifactId>
+      <scope>provided</scope>
+    </dependency>
 
-       <dependency>
-          <groupId>org.apache.lucene</groupId>
-          <artifactId>lucene-test-framework</artifactId>
-          <version>${lucene.maven.version}</version>
-          <scope>test</scope>
-        </dependency>
+    <dependency>
+      <groupId>org.elasticsearch</groupId>
+      <artifactId>elasticsearch</artifactId>
+      <type>test-jar</type>
+    </dependency>
 
-        <dependency>
-          <groupId>org.apache.httpcomponents</groupId>
-          <artifactId>httpclient</artifactId>
-          <version>4.3.5</version>
-          <scope>test</scope>
-        </dependency>
+  </dependencies>
 
-        <dependency>
-          <groupId>com.carrotsearch.randomizedtesting</groupId>
-          <artifactId>randomizedtesting-runner</artifactId>
-          <version>2.1.10</version>
-          <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.elasticsearch</groupId>
-            <artifactId>elasticsearch</artifactId>
-            <version>${elasticsearch.version}</version>
-        </dependency>
+  <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>com.carrotsearch.randomizedtesting</groupId>
+        <artifactId>junit4-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 
-        <dependency>
-          <groupId>org.elasticsearch</groupId>
-          <artifactId>elasticsearch</artifactId>
-          <version>${elasticsearch.version}</version>
-          <type>test-jar</type>
-          <scope>test</scope>
-        </dependency>
-
-        <dependency>
-          <groupId>org.hamcrest</groupId>
-          <artifactId>hamcrest-all</artifactId>
-          <version>1.3</version>
-          <scope>test</scope>
-        </dependency>
-
-        <dependency>
-          <groupId>junit</groupId>
-          <artifactId>junit</artifactId>
-          <version>4.10</version>
-          <scope>test</scope>
-        </dependency>
-
-    </dependencies>
-    <build>
-        <!-- Create a zip file according to elasticsearch naming scheme -->
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <version>1.6</version>
-                <executions>
-                    <execution>
-                        <id>zip</id>
-                        <phase>package</phase>
-                        <configuration>
-                            <target>
-                                <zip basedir="${project.build.directory}"
-                                     includes="${project.build.finalName}.jar"
-                                     destfile="${project.build.directory}/${project.artifactId}-${project.version}.zip" />
-                            </target>
-                        </configuration>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <configuration>
-                        <source>1.7</source>
-                        <target>1.7</target>
-                    </configuration>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-    </build>
+  <repositories>
+    <repository>
+      <id>oss-snapshots</id>
+      <name>Sonatype OSS Snapshots</name>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+    </repository>
+  </repositories>
 </project>

--- a/script/ci/run_build.sh
+++ b/script/ci/run_build.sh
@@ -1,0 +1,2 @@
+#! /usr/bin/env sh
+mvn -Delasticsearch.version=$ES_VERSION -Dtests.security.manager=false test

--- a/src/main/assemblies/plugin.xml
+++ b/src/main/assemblies/plugin.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<assembly>
+    <id>plugin</id>
+    <formats>
+        <format>zip</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>/</outputDirectory>
+            <useProjectArtifact>true</useProjectArtifact>
+            <useTransitiveFiltering>true</useTransitiveFiltering>
+            <excludes>
+                <exclude>org.elasticsearch:elasticsearch</exclude>
+            </excludes>
+        </dependencySet>
+        <dependencySet>
+            <outputDirectory>/</outputDirectory>
+            <useProjectArtifact>true</useProjectArtifact>
+            <useTransitiveFiltering>true</useTransitiveFiltering>
+            <includes>
+                <include>com.asquera.elasticsearch:elasticsearch-http-basic</include>
+            </includes>
+        </dependencySet>
+    </dependencySets>
+</assembly>

--- a/src/main/java/com/asquera/elasticsearch/plugins/http/HttpBasicServer.java
+++ b/src/main/java/com/asquera/elasticsearch/plugins/http/HttpBasicServer.java
@@ -56,9 +56,12 @@ public class HttpBasicServer extends HttpServer {
 
         this.user = settings.get("http.basic.user", "admin");
         this.password = settings.get("http.basic.password", "admin_pw");
-        this.whitelist = new InetAddressWhitelist(
-                settings.getAsArray("http.basic.ipwhitelist",
-                  new String[]{"localhost", "127.0.0.1"}));
+        final boolean whitelistEnabled = settings.getAsBoolean("http.basic.ipwhitelist", true);
+        String [] whitelisted = new String[0];
+        if (whitelistEnabled) {
+            whitelisted = settings.getAsArray("http.basic.ipwhitelist", new String[]{"localhost", "127.0.0.1"});
+        }
+        this.whitelist = new InetAddressWhitelist(whitelisted);
         this.proxyChains = new ProxyChains(
             settings.getAsArray(
               "http.basic.trusted_proxy_chains", new String[]{""}));

--- a/src/test/java/com/asquera/elasticsearch/plugins/http/auth/integration/DisabledWhitelistIntegrationTest.java
+++ b/src/test/java/com/asquera/elasticsearch/plugins/http/auth/integration/DisabledWhitelistIntegrationTest.java
@@ -33,12 +33,12 @@ import static org.hamcrest.Matchers.equalTo;
  * Test a rest action that sets special response headers
  */
 @ClusterScope(transportClientRatio = 0.0, scope = Scope.SUITE, numDataNodes = 1)
-public class EmptyWhitelistIntegrationTest extends HttpBasicServerPluginIntegrationTest {
+public class DisabledWhitelistIntegrationTest extends HttpBasicServerPluginIntegrationTest {
 
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {
         return  builderWithPlugin().
-                putArray("http.basic.ipwhitelist", "unkown")
+                put("http.basic.ipwhitelist", false)
                  .build();
     }
 

--- a/src/test/java/com/asquera/elasticsearch/plugins/http/auth/integration/EmptyWhitelistIntegrationTest.java
+++ b/src/test/java/com/asquera/elasticsearch/plugins/http/auth/integration/EmptyWhitelistIntegrationTest.java
@@ -62,4 +62,11 @@ public class EmptyWhitelistIntegrationTest extends HttpBasicServerPluginIntegrat
         assertThat(response.getStatusCode()
             , equalTo(RestStatus.UNAUTHORIZED.getStatus()));
     }
+
+    @Test
+    public void clientBadCredentialsSanityCheckOk() throws Exception {
+        HttpResponse response = requestWithCredentials("admin:wrong").path("/").execute();
+        assertThat(response.getStatusCode()
+            , equalTo(RestStatus.OK.getStatus()));
+    }
 }

--- a/src/test/java/com/asquera/elasticsearch/plugins/http/auth/integration/HttpBasicServerPluginIntegrationTest.java
+++ b/src/test/java/com/asquera/elasticsearch/plugins/http/auth/integration/HttpBasicServerPluginIntegrationTest.java
@@ -19,7 +19,7 @@ import org.elasticsearch.common.settings.ImmutableSettings;
  * @author Ernesto Miguez (ernesto.miguez@asquera.de)
  */
 
-public abstract class HttpBasicServerPluginIntegrationTest extends
+public class HttpBasicServerPluginIntegrationTest extends
 ElasticsearchIntegrationTest {
 
   protected final String localhost = "127.0.0.1";

--- a/src/test/java/com/asquera/elasticsearch/plugins/http/auth/integration/IpAuthenticationIntegrationTest.java
+++ b/src/test/java/com/asquera/elasticsearch/plugins/http/auth/integration/IpAuthenticationIntegrationTest.java
@@ -102,10 +102,4 @@ public class IpAuthenticationIntegrationTest extends HttpBasicServerPluginIntegr
           assertThat(response.getStatusCode(), equalTo(RestStatus.UNAUTHORIZED.getStatus()));
         }
     }
-
-    protected HttpRequestBuilder requestWithCredentials(String credentials) throws Exception {
-        return httpClient().path("/_status")
-          .addHeader("Authorization", "Basic " + Base64.encodeBytes(credentials.getBytes()));
-    }
-
 }

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,0 +1,5 @@
+log4j.rootLogger=INFO, out
+
+log4j.appender.out=org.apache.log4j.ConsoleAppender
+log4j.appender.out.layout=org.apache.log4j.PatternLayout
+log4j.appender.out.layout.conversionPattern=[%d{ISO8601}][%-5p][%-25c] %m%n


### PR DESCRIPTION
- add travis configuration matrix for ES versions
- add script to run travis with ES version variable
- add travis cache
- update pom to depend on elasticsearch-parent project, which spimplifies plugin
mantenance
- allow for disabling the ip whitelist