### PR TITLE
fix: log http method type in requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Use  `date "+%Y-%m-%d"` to get the correct date formatting
 ## [Unreleased][unreleased]
 ### - Added
 - allow HEAD root url authentication #39
+- log http method on any request. #42
 
 ## [1.5.0][2015-07-04]
 

--- a/src/main/java/com/asquera/elasticsearch/plugins/http/HttpBasicServer.java
+++ b/src/main/java/com/asquera/elasticsearch/plugins/http/HttpBasicServer.java
@@ -204,10 +204,11 @@ public class HttpBasicServer extends HttpServer {
 
     public void logRequest(final HttpRequest request) {
       String addr = getAddress(request).getHostAddress();
-      String t = "Authorization:{}, Host:{}, Path:{}, {}:{}, Request-IP:{}, " +
+      String t = "Authorization:{}, type: {}, Host:{}, Path:{}, {}:{}, Request-IP:{}, " +
         "Client-IP:{}, X-Client-IP{}";
       logger.info(t,
                   request.header("Authorization"),
+                  request.method(),
                   request.header("Host"),
                   request.path(),
                   xForwardHeader,


### PR DESCRIPTION
Http method type was only logged for unauthorized requests.
This pr adds  the Http method type to the logs of any request

closes #42