### PR TITLE
test: remove httpClient() override

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 sudo: false
 language: java
-script: ./script/ci/run_build.sh
+install:
+  - mvn install -Delasticsearch.version=$ES_VERSION -DskipTests=true
+script:
+  - mvn -Delasticsearch.version=$ES_VERSION -Dtests.security.manager=false test
 env:
-  - ES_VERSION=1.5.0
   - ES_VERSION=1.5.1
   - ES_VERSION=1.5.2
   - ES_VERSION=1.6.0
 cache:
   directories:
-    - $HOME/.m2
+  - $HOME/.m2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Use  `date "+%Y-%m-%d"` to get the correct date formatting
 ### - Added
 - allow HEAD root url authentication #39
 - log http method on any request. #42
+### - Fix
+- test: adapt to method signature change after 1.5.1 #55
+- test: run custom install and test commands in ci
 
 ## [1.5.0][2015-07-04]
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ There is no way to configure this on a per index basis.
 
 |     Http Basic Plugin       | elasticsearch         |
 |-----------------------------|-----------------------|
-| v1.5.0(master)              | 1.5.x, 1.6.x          |
+| v1.5.1(master)              | 1.5.1, 1.5.2, 1.6.x   |
+| v1.5.0                      | 1.5.0                 |
 | v1.4.0                      | 1.4.0                 |
 | v1.3.0                      | 1.3.0                 |
 | v1.2.0                      | 1.2.0                 |

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-  exmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.asquera.elasticsearch</groupId>

--- a/script/ci/run_build.sh
+++ b/script/ci/run_build.sh
@@ -1,2 +1,0 @@
-#! /usr/bin/env sh
-mvn -Delasticsearch.version=$ES_VERSION -Dtests.security.manager=false test

--- a/src/test/java/com/asquera/elasticsearch/plugins/http/auth/integration/HttpBasicServerPluginIntegrationTest.java
+++ b/src/test/java/com/asquera/elasticsearch/plugins/http/auth/integration/HttpBasicServerPluginIntegrationTest.java
@@ -25,11 +25,6 @@ ElasticsearchIntegrationTest {
   protected final String localhost = "127.0.0.1";
 
 
-  public static HttpRequestBuilder httpClient() {
-    HttpServerTransport httpServerTransport = internalCluster().getDataNodeInstance(HttpServerTransport.class);
-    InetSocketAddress address = ((InetSocketTransportAddress) httpServerTransport.boundAddress().publishAddress()).address();
-    return new HttpRequestBuilder(HttpClients.createDefault()).host(address.getHostName()).port(address.getPort());
-  }
   /**
    *
    * @return a Builder with the plugin included and bind_host and publish_host


### PR DESCRIPTION
The parent class has declared the method private from ES version 1.5.2
Removing the method fixes the problem

Fixes #55