### PR TITLE
1.5.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,12 @@
       <type>test-jar</type>
     </dependency>
 
+    <dependency>
+    	<groupId>commons-net</groupId>
+    	<artifactId>commons-net</artifactId>
+    	<version>3.3</version>
+    	<scope>provided</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/asquera/elasticsearch/plugins/http/HttpBasicServer.java
+++ b/src/main/java/com/asquera/elasticsearch/plugins/http/HttpBasicServer.java
@@ -158,7 +158,7 @@ public class HttpBasicServer extends HttpServer {
                 String givenPass = userAndPassword[1];
                 if (this.user.equals(givenUser) && this.password.equals(givenPass))
                     return true;
-            }
+            }            
         } catch (Exception e) {
             logger.warn("Retrieving of user and password failed for " + decoded + " ," + e.getMessage());
         }

--- a/src/main/java/com/asquera/elasticsearch/plugins/http/auth/InetAddressWhitelist.java
+++ b/src/main/java/com/asquera/elasticsearch/plugins/http/auth/InetAddressWhitelist.java
@@ -1,4 +1,7 @@
 package com.asquera.elasticsearch.plugins.http.auth;
+
+import org.apache.commons.net.util.SubnetUtils;
+
 import org.elasticsearch.common.logging.Loggers;
 
 import java.util.ArrayList;
@@ -12,8 +15,8 @@ import java.net.UnknownHostException;
 
 /**
  *
- * Wraps the configured whitelisted ips.
- * It uses a set of {@link InetAddress} internally.
+ * Wraps the configured whitelisted ips. It uses a set of {@link InetAddress}
+ * internally.
  * <p>
  *
  *
@@ -22,95 +25,117 @@ import java.net.UnknownHostException;
  */
 
 public class InetAddressWhitelist {
-  private Set<InetAddress> whitelist;
-  /**
-   *
-   *
-   * @param whitelist
-   */
-  public InetAddressWhitelist(Set<InetAddress> whitelist) {
-    this.whitelist = whitelist;
-  }
+	private Set<InetAddress> whitelist;
 
-  /**
-   *
-   *
-   * @param sWhitelist
-   *
-   */
-  public InetAddressWhitelist(String[] sWhitelist) {
-    this(toInetAddress(Arrays.asList(sWhitelist)));
-  }
+	/**
+	 *
+	 *
+	 * @param whitelist
+	 */
+	public InetAddressWhitelist(Set<InetAddress> whitelist) {
+		this.whitelist = whitelist;
+	}
 
-  /**
-   * Checks the request ip for inclusion.
-   * Since that ip comes in a {@link InetAddress} representation, it is checked
-   * against the whitelist.
-   *
-   * @param candidate
-   * @return if the ip is included in the whitelist
-   */
-  public Boolean contains(InetAddress candidate) {
-    return this.whitelist.contains(candidate);
-  }
+	/**
+	 *
+	 *
+	 * @param sWhitelist
+	 *
+	 */
+	public InetAddressWhitelist(String[] sWhitelist) {
+		this(toInetAddress(Arrays.asList(sWhitelist)));
+	}
 
-  /**
-   *
-   * Checks the xForwardedFor defined client ip for inclusion.
-   * Since that ip comes in a String representation, it is checked against
-   * the String representation of the defined whitelist.
-   *
-   * @param candidate
-   * @return if the ip is included in the String representation of the
-   * whitelist ips
-   */
-  public Boolean contains(String candidate) {
-    return getStringWhitelist().contains(candidate);
-  }
+	/**
+	 * Checks the request ip for inclusion. Since that ip comes in a
+	 * {@link InetAddress} representation, it is checked against the whitelist.
+	 *
+	 * @param candidate
+	 * @return if the ip is included in the whitelist
+	 */
+	public Boolean contains(InetAddress candidate) {
+		return this.whitelist.contains(candidate);
+	}
 
-  /**
-   * @return set of the string representations of the whitelist
-   */
-  Set<String> getStringWhitelist() {
-    Iterator<InetAddress> iterator = this.whitelist.iterator();
-    Set<String> set = new HashSet<String>();
-    while (iterator.hasNext()) {
-      InetAddress next = iterator.next();
-      set.add(next.getHostAddress());
-    }
-    return set;
-  }
+	/**
+	 *
+	 * Checks the xForwardedFor defined client ip for inclusion. Since that ip
+	 * comes in a String representation, it is checked against the String
+	 * representation of the defined whitelist.
+	 *
+	 * @param candidate
+	 * @return if the ip is included in the String representation of the
+	 *         whitelist ips
+	 */
+	public Boolean contains(String candidate) {
+		return getStringWhitelist().contains(candidate);
+	}
 
-  /**
-   * when an configured InetAddress is Unkown or Invalid it is dropped from the
-   * whitelist
-   *
-   * @param  ips a list of string ips
-   * @return a list of {@link InetAddress} objects
-   *
-   */
-  static Set<InetAddress> toInetAddress(List<String> ips) {
-    List<InetAddress> listIps = new ArrayList<InetAddress>();
-    Iterator<String> iterator = ips.iterator();
-    while (iterator.hasNext()) {
-      String next = iterator.next();
-      try {
-        listIps.add(InetAddress.getByName(next));
-      } catch (UnknownHostException e) {
-        String template = "an ip set in the whitelist settings raised an " +
-          "UnknownHostException: {}, dropping it";
-        Loggers.getLogger(InetAddressWhitelist.class).info(template, e.getMessage());
-      }
-    }
-    return new HashSet<InetAddress>(listIps);
-  }
+	/**
+	 * @return set of the string representations of the whitelist
+	 */
+	Set<String> getStringWhitelist() {
+		Iterator<InetAddress> iterator = this.whitelist.iterator();
+		Set<String> set = new HashSet<String>();
+		while (iterator.hasNext()) {
+			InetAddress next = iterator.next();
+			set.add(next.getHostAddress());
+		}
+		return set;
+	}
 
-  /**
-   * delegate method
-   */
-  @Override
-  public String toString() {
-    return whitelist.toString();
-  }
+	/**
+	 * when an configured InetAddress is Unkown or Invalid it is dropped from
+	 * the whitelist
+	 *
+	 * @param ips
+	 *            a list of string ips
+	 * @return a list of {@link InetAddress} objects
+	 *
+	 */
+	static Set<InetAddress> toInetAddress(List<String> ips) {
+		List<InetAddress> listIps = new ArrayList<InetAddress>();
+		Iterator<String> iterator = ips.iterator();
+		while (iterator.hasNext()) {
+			String next = iterator.next();
+			if (next == null) {
+				continue;
+			}
+
+			try {
+				if (next.contains("/")) {
+					SubnetUtils subnetUtils = new SubnetUtils(next);
+					String[] allAddressesInRange = subnetUtils.getInfo().getAllAddresses();
+					for (String addressInRange : allAddressesInRange) {
+						listIps.add(InetAddress.getByName(addressInRange));
+					}
+				} else {
+					listIps.add(InetAddress.getByName(next));
+				}
+			} catch (UnknownHostException e) {
+				String template = "an ip set in the whitelist settings raised an "
+						+ "UnknownHostException: {}, dropping it";
+				Loggers.getLogger(InetAddressWhitelist.class).info(template, e.getMessage());
+			}
+		}
+
+		try {
+			listIps.add(InetAddress.getByName("localhost"));
+		} catch (UnknownHostException e) {
+			String template = "an ip set in the whitelist settings raised an "
+					+ "UnknownHostException: {}, dropping it";
+			Loggers.getLogger(InetAddressWhitelist.class).info(template, e.getMessage());
+		}
+
+		return new HashSet<InetAddress>(listIps);
+	}
+
+	/**
+	 * delegate method
+	 */
+	@Override
+	public String toString() {
+		return whitelist.toString();
+	}
 
 }

--- a/src/main/java/com/asquera/elasticsearch/plugins/http/auth/InetAddressWhitelist.java
+++ b/src/main/java/com/asquera/elasticsearch/plugins/http/auth/InetAddressWhitelist.java
@@ -107,8 +107,6 @@ public class InetAddressWhitelist {
 					SubnetUtils subnetUtils = new SubnetUtils(next);
 					String[] allAddressesInRange = subnetUtils.getInfo().getAllAddresses();
 					for (String addressInRange : allAddressesInRange) {
-						// Remove "/" that is in front of every address by default.
-						addressInRange = addressInRange.substring(1);
 						listIps.add(InetAddress.getByName(addressInRange));
 					}
 				} else {

--- a/src/main/java/com/asquera/elasticsearch/plugins/http/auth/InetAddressWhitelist.java
+++ b/src/main/java/com/asquera/elasticsearch/plugins/http/auth/InetAddressWhitelist.java
@@ -107,6 +107,8 @@ public class InetAddressWhitelist {
 					SubnetUtils subnetUtils = new SubnetUtils(next);
 					String[] allAddressesInRange = subnetUtils.getInfo().getAllAddresses();
 					for (String addressInRange : allAddressesInRange) {
+						// Remove "/" that is in front of every address by default.
+						addressInRange = addressInRange.substring(1);
 						listIps.add(InetAddress.getByName(addressInRange));
 					}
 				} else {


### PR DESCRIPTION
**Added support for CIDR subnet white listing**

We added support for CIDR subnet whitelisting (e.g. just write 192.168.31.0/24 to whitelist the entire subnet). This was a requirement for our production environment.

We tried to keep things simple and just add all IP addresses from the range to the whitelist on time of creation. So no other logic was changed.