### PR TITLE
Calling healthcheck shouldn't trigger unauthorized log

### DIFF
--- a/src/main/java/com/asquera/elasticsearch/plugins/http/HttpBasicServer.java
+++ b/src/main/java/com/asquera/elasticsearch/plugins/http/HttpBasicServer.java
@@ -130,14 +130,14 @@ public class HttpBasicServer extends HttpServer {
                             new XForwardedFor(xForwardedFor),
                             proxyChains);
       ipAuthorized = client.isAuthorized();
-      if (ipAuthorized) {
-        if (log) {
+      if (log) {
+        if (ipAuthorized) {
           String template = "Ip Authorized client: {}";
           Loggers.getLogger(getClass()).info(template, client);
+        } else {
+          String template = "Ip Unauthorized client: {}";
+          Loggers.getLogger(getClass()).error(template, client);
         }
-      } else {
-        String template = "Ip Unauthorized client: {}";
-        Loggers.getLogger(getClass()).error(template, client);
       }
       return ipAuthorized;
     }


### PR DESCRIPTION
Unauthorized calls are already logged through logUnAuthorizedRequest
method.